### PR TITLE
filename format changing, no more mapping

### DIFF
--- a/lib/awesomelists-index.js
+++ b/lib/awesomelists-index.js
@@ -12,7 +12,7 @@ class Awesome {
 
     this.token = options.token;
     this.repo = options.repo;
-    this.filename = `${this.getFilename()}.json`;
+    this.filename = `${this.repo.replace('/', '-')}.json`;
   }
 
   getReadmeHTML(callback) {
@@ -35,11 +35,6 @@ class Awesome {
         console.log(`Can not get ${this.repo}'s README form github. Reason: ${body}`);
       }
     });
-  }
-
-  getFilename() {
-    let nameMap = jsonfile.readFileSync(`${__dirname}/repo-file-name.json`);
-    return nameMap[this.repo];
   }
 
   makeIndexJson(callback) {


### PR DESCRIPTION
Just change some website's behaviours of retrieving JSON file.
each JSON file name of awesome repos will be <maintainer>-<repo-name>.json, no need the mapping table now :+1: 

https://github.com/lockys/awesome-search/blob/gh-pages/src%2Fjs%2Findex.js#L139
https://github.com/lockys/awesome.json/tree/master/repo-json
